### PR TITLE
use ConnectionPool directly for sqlserver over connect function

### DIFF
--- a/src/adapters/sqlserver.ts
+++ b/src/adapters/sqlserver.ts
@@ -506,7 +506,6 @@ export default class SqlServerAdapter extends AbstractAdapter {
   }
 
   async driverExecuteQuery<T = unknown>(queryArgs: QueryArgs, connection?: ConnectionPool): Promise<QueryResult<T>> {
-    connection = connection || this.conn.connection;
     const runQuery = async (connection: ConnectionPool): Promise<QueryResult<T>> => {
       const request = connection.request();
       if (queryArgs.multiple) {
@@ -530,7 +529,9 @@ export default class SqlServerAdapter extends AbstractAdapter {
   }
 
   async runWithConnection<T = QueryResult>(run: (connection: ConnectionPool) => Promise<T>): Promise<T> {
-    this.conn.connection = await (new ConnectionPool(this.conn.dbConfig)).connect();
+    if (!this.conn.connection) {
+      this.conn.connection = await (new ConnectionPool(this.conn.dbConfig)).connect();
+    }
     return run(this.conn.connection);
   }
 


### PR DESCRIPTION
While `connect` is the recommended way to use mssql@6, it causes a bug here where on switching SQL Servers, it will continue to use the ConnectionPool that was constructed for the first server even though the config object is different and it's a new instantiation of the overall `SqlServerAdapter`, as it ignores the object if there's an available global pool.