### PR TITLE
Fix vulnerability at xmldom from mssql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4840,9 +4840,9 @@
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmldom": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-      "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xpath.js": {
       "version": "1.1.0",


### PR DESCRIPTION
```
 npm audit

                       === npm audit security report ===

# Run  npm update xmldom --depth 5  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Misinterpretation of malicious XML input                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ xmldom                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ mssql                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ mssql > tedious > @azure/ms-rest-nodeauth > adal-node >      │
│               │ xmldom                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1650                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 1 low severity vulnerability in 598 scanned packages
  run `npm audit fix` to fix 1 of them.
```