### PR TITLE
Allow filter to be optional to adapter methods

### DIFF
--- a/src/adapters/abstract_adapter.ts
+++ b/src/adapters/abstract_adapter.ts
@@ -76,19 +76,19 @@ export abstract class AbstractAdapter {
   abstract listDatabases(filter?: DatabaseFilter): Promise<string[]>;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  listSchemas(filter: SchemaFilter): Promise<string[]> {
+  listSchemas(filter?: SchemaFilter): Promise<string[]> {
     return Promise.resolve([]);
   }
 
-  abstract listTables(filter: SchemaFilter): Promise<ListTableResult[]>;
+  abstract listTables(filter?: SchemaFilter): Promise<ListTableResult[]>;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  listViews(filter: SchemaFilter): Promise<ListViewResult[]> {
+  listViews(filter?: SchemaFilter): Promise<ListViewResult[]> {
     return Promise.resolve([]);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  listRoutines(filter: SchemaFilter): Promise<ListRoutineResult[]> {
+  listRoutines(filter?: SchemaFilter): Promise<ListRoutineResult[]> {
     return Promise.resolve([]);
   }
 

--- a/src/adapters/postgresql.ts
+++ b/src/adapters/postgresql.ts
@@ -147,7 +147,7 @@ export default class PostgresqlAdapter extends AbstractAdapter {
     return data.rows.map((row) => row.datname);
   }
 
-  async listTables(filter: SchemaFilter): Promise<ListTableResult[]> {
+  async listTables(filter?: SchemaFilter): Promise<ListTableResult[]> {
     const schemaFilter = buildSchemaFilter(filter, 'table_schema');
     const sql = `
       SELECT
@@ -164,7 +164,7 @@ export default class PostgresqlAdapter extends AbstractAdapter {
     return data.rows;
   }
 
-  async listViews(filter: SchemaFilter): Promise<ListViewResult[]> {
+  async listViews(filter?: SchemaFilter): Promise<ListViewResult[]> {
     const schemaFilter = buildSchemaFilter(filter, 'table_schema');
     const sql = `
       SELECT
@@ -180,7 +180,7 @@ export default class PostgresqlAdapter extends AbstractAdapter {
     return data.rows;
   }
 
-  async listRoutines(filter: SchemaFilter): Promise<ListRoutineResult[]> {
+  async listRoutines(filter?: SchemaFilter): Promise<ListRoutineResult[]> {
     const schemaFilter = buildSchemaFilter(filter, 'routine_schema');
     const sql = `
       SELECT
@@ -256,7 +256,7 @@ export default class PostgresqlAdapter extends AbstractAdapter {
     return data.rows.map((row) => row.index_name);
   }
 
-  async listSchemas(filter: SchemaFilter): Promise<string[]> {
+  async listSchemas(filter?: SchemaFilter): Promise<string[]> {
     const schemaFilter = buildSchemaFilter(filter);
     const sql = `
       SELECT schema_name

--- a/src/adapters/sqlite.ts
+++ b/src/adapters/sqlite.ts
@@ -18,6 +18,7 @@ import type {
 } from './abstract_adapter';
 import type { Server } from '../server';
 import type { Database } from '../database';
+import { SchemaFilter } from '..';
 
 const logger = createLogger('db:clients:sqlite');
 
@@ -116,7 +117,10 @@ export default class SqliteAdapter extends AbstractAdapter {
     });
   }
 
-  async listTables(filter: unknown, connection?: sqlite3.Database): Promise<ListTableResult[]> {
+  async listTables(
+    filter?: SchemaFilter,
+    connection?: sqlite3.Database,
+  ): Promise<ListTableResult[]> {
     const sql = `
       SELECT name
       FROM sqlite_master

--- a/src/adapters/sqlite.ts
+++ b/src/adapters/sqlite.ts
@@ -211,7 +211,7 @@ export default class SqliteAdapter extends AbstractAdapter {
 
   async truncateAllTables(): Promise<void> {
     await this.runWithConnection(async (connection) => {
-      const tables = await this.listTables(null, connection);
+      const tables = await this.listTables(undefined, connection);
 
       const truncateAll = tables
         .map(

--- a/src/adapters/sqlserver.ts
+++ b/src/adapters/sqlserver.ts
@@ -131,7 +131,7 @@ export default class SqlServerAdapter extends AbstractAdapter {
     return data.map((row) => row.name);
   }
 
-  async listSchemas(filter: SchemaFilter): Promise<string[]> {
+  async listSchemas(filter?: SchemaFilter): Promise<string[]> {
     const schemaFilter = buildSchemaFilter(filter);
     const sql = `
       SELECT schema_name
@@ -145,7 +145,7 @@ export default class SqlServerAdapter extends AbstractAdapter {
     return data.map((row) => row.schema_name);
   }
 
-  async listTables(filter: SchemaFilter): Promise<ListTableResult[]> {
+  async listTables(filter?: SchemaFilter): Promise<ListTableResult[]> {
     const schemaFilter = buildSchemaFilter(filter, 'table_schema');
     const sql = `
       SELECT
@@ -165,7 +165,7 @@ export default class SqlServerAdapter extends AbstractAdapter {
     }));
   }
 
-  async listViews(filter: SchemaFilter): Promise<ListViewResult[]> {
+  async listViews(filter?: SchemaFilter): Promise<ListViewResult[]> {
     const schemaFilter = buildSchemaFilter(filter, 'table_schema');
     const sql = `
       SELECT
@@ -184,7 +184,7 @@ export default class SqlServerAdapter extends AbstractAdapter {
     }));
   }
 
-  async listRoutines(filter: SchemaFilter): Promise<ListRoutineResult[]> {
+  async listRoutines(filter?: SchemaFilter): Promise<ListRoutineResult[]> {
     const schemaFilter = buildSchemaFilter(filter, 'routine_schema');
     const sql = `
       SELECT

--- a/src/database.ts
+++ b/src/database.ts
@@ -106,23 +106,23 @@ export class Database {
     return (<AbstractAdapter>this.connection).listDatabases(filter);
   }
 
-  listSchemas(filter: SchemaFilter): Promise<string[]> {
+  listSchemas(filter?: SchemaFilter): Promise<string[]> {
     this.checkIsConnected();
     return (<AbstractAdapter>this.connection).listSchemas(filter);
   }
 
-  listTables(filter: SchemaFilter): Promise<{ name: string }[]> {
+  listTables(filter?: SchemaFilter): Promise<{ name: string }[]> {
     this.checkIsConnected();
     return (<AbstractAdapter>this.connection).listTables(filter);
   }
 
-  listViews(filter: SchemaFilter): Promise<{ name: string }[]> {
+  listViews(filter?: SchemaFilter): Promise<{ name: string }[]> {
     this.checkIsConnected();
     return (<AbstractAdapter>this.connection).listViews(filter);
   }
 
   listRoutines(
-    filter: SchemaFilter,
+    filter?: SchemaFilter,
   ): Promise<
     {
       schema?: string;


### PR DESCRIPTION
Within sqlectron-gui, the filter that gets passed down to the adapter may or not be set, and so need to allow the adapter to allow this within its type definitions.